### PR TITLE
Feat/sang/#37: 헤더의 배송지 등록 기능 구현

### DIFF
--- a/src/lib/components/header.js
+++ b/src/lib/components/header.js
@@ -1,4 +1,4 @@
-import { insertLast, getNode } from '/src/lib';
+import { insertLast, getNode, getStorage } from '/src/lib';
 
 const header = document.querySelector('.header');
 const headerMenubar = document.querySelector('.menu');
@@ -22,7 +22,13 @@ const handleScrollHeader = e => {
 }
 
 const handleSetAddress = () => {
-  window.open('/src/pages/address/', '_blank', 'width=502,height=547');
+  const width = 502;
+  const height = 547;
+  const popupX = (screen.width / 2) - (width / 2);
+  const popupY = (screen.height / 2) - (height / 2);
+  window.open('/src/pages/address/', '_blank', `width=${width},height=${height},left=${popupX},top=${popupY}`);
+  isShowAddressBox = !isShowAddressBox;
+  menuLink.removeChild(getNode('.menu_link__address-box'))
 }
 
 const promiseInsertLast = (target, template) => {
@@ -36,22 +42,38 @@ const setSearchAddressEvent = (target) => {
   target.addEventListener('click', handleSetAddress)
 }
 
-const handleAddressBox = () => {
+const handleAddressBox = async () => {
+  let template;
+  const address = JSON.parse(await getStorage('address'));
 
-  const template = /* html */`
+  // 이 부분에서 로그인 기능 구현 이후 로그인했을 경우 주소를 가져오는 로직도 추가해야 한다.
+  if(!address) {
+    template = /* html */`
+      <div class="menu_link__address-box">
+        <p><strong>배송지를 등록</strong>하고</p>
+        <p>구매 가능한 상품을 확인하세요!</p>
+        <div class="menu_link__address-box--container">
+          <a href="/src/pages/login/">로그인</a>
+          <button type="button" class="address-box-search">주소 검색</button>
+        </div>
+      </div>
+    `
+  } else {
+    template = /* html */`
     <div class="menu_link__address-box">
-      <p><strong>배송지를 등록</strong>하고</p>
-      <p>구매 가능한 상품을 확인하세요!</p>
+      <p>${address["address"]} ${address["detail-address"]}</p>
+      <p class="deliver_type">샛별배송</p>
       <div class="menu_link__address-box--container">
-        <a href="/src/pages/login/">로그인</a>
-        <button type="button" class="address-box-search"><span></span>주소 검색</button>
+        <button type="button" class="address-box-search research">배송지 변경</button>
       </div>
     </div>
   `
+  }
+
   if(!isShowAddressBox) {
     isShowAddressBox = !isShowAddressBox;
     promiseInsertLast(menuLink, template)
-    .then(setSearchAddressEvent(getNode('.address-box-search')));
+    .then(setSearchAddressEvent(getNode('.address-box-search')))
   } else {
     isShowAddressBox = !isShowAddressBox;
     menuLink.removeChild(getNode('.menu_link__address-box'));

--- a/src/lib/components/header.js
+++ b/src/lib/components/header.js
@@ -1,7 +1,13 @@
+import { insertLast, getNode } from '/src/lib';
+
 const header = document.querySelector('.header');
 const headerMenubar = document.querySelector('.menu');
 
-const handleHeaderScroll = e => {
+const menuLink = document.querySelector('.menu_link')
+const addressButton = document.querySelector('.menu_link__address');
+let isShowAddressBox = false;
+
+const handleScrollHeader = e => {
 
   const currentPosition = window.scrollY;
   const headerPosition = header.getBoundingClientRect().height
@@ -15,5 +21,37 @@ const handleHeaderScroll = e => {
   }
 }
 
+const handleAddressBox = () => {
 
-export const fixHeader = () => document.addEventListener('scroll', handleHeaderScroll);
+  
+  const template = /* html */`
+    <div class="menu_link__address-box">
+      <p><strong>배송지를 등록</strong>하고</p>
+      <p>구매 가능한 상품을 확인하세요!</p>
+      <div class="menu_link__address-box--container">
+        <a href="/src/pages/login/">로그인</a>
+        <button type="button" class="address-box-search"><span></span>주소 검색</button>
+      </div>
+    </div>
+  `
+  if(!isShowAddressBox) {
+    isShowAddressBox = !isShowAddressBox;
+    insertLast(menuLink, template);
+  } else {
+    isShowAddressBox = !isShowAddressBox;
+    menuLink.removeChild(getNode('.menu_link__address-box'));
+  }
+
+}
+
+
+
+
+
+const fixHeader = () => document.addEventListener('scroll', handleScrollHeader);
+const showAddressBox = () => addressButton.addEventListener('click', handleAddressBox);
+
+export const initHeader = () => {
+  fixHeader();
+  showAddressBox();
+}

--- a/src/lib/components/header.js
+++ b/src/lib/components/header.js
@@ -21,9 +21,23 @@ const handleScrollHeader = e => {
   }
 }
 
+const handleSetAddress = () => {
+  window.open('/src/pages/address/', '_blank', 'width=502,height=547');
+}
+
+const promiseInsertLast = (target, template) => {
+
+  return new Promise((resolve, reject) => {
+    resolve(insertLast(target, template))
+  });
+}
+
+const setSearchAddressEvent = (target) => {
+  target.addEventListener('click', handleSetAddress)
+}
+
 const handleAddressBox = () => {
 
-  
   const template = /* html */`
     <div class="menu_link__address-box">
       <p><strong>배송지를 등록</strong>하고</p>
@@ -36,11 +50,13 @@ const handleAddressBox = () => {
   `
   if(!isShowAddressBox) {
     isShowAddressBox = !isShowAddressBox;
-    insertLast(menuLink, template);
+    promiseInsertLast(menuLink, template)
+    .then(setSearchAddressEvent(getNode('.address-box-search')));
   } else {
     isShowAddressBox = !isShowAddressBox;
     menuLink.removeChild(getNode('.menu_link__address-box'));
   }
+
 
 }
 

--- a/src/pages/address/index.html
+++ b/src/pages/address/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
+  <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+  <script type="module" src="/src/pages/address/index.js"></script>
+  <title>칼리 - 마켓칼리 주소입력</title>
+</head>
+<body>
+  <header class="address-header">
+    <h1><strong>샛별배송</strong> 지역입니다.</h1>
+    <h3>매일 새벽, 문 앞까지 신선함을 전해드려요.</h3>
+  </header>
+
+  <main class="address-main">
+    <div class="address-result">
+      <input type="hidden" name="selected-zipcode" id="selected-zipcode" />
+      <input type="text" name="selected-address" id="selected-address" disabled />
+      <button type="button" class="address-research">재검색</button>
+    </div>
+    <input type="text" name="address-detail" 
+            id="address-detail" 
+            class="address-detail"
+            placeholder="나머지 주소를 입력해 주세요" />
+
+    <div class="delete-address-info">
+      <span>&#8251; 저장된 배송지는 최대 7일 간 임시 저장 후 자동 삭제됩니다.</span>
+    </div>
+
+    <button class="address-save">저장</button>
+
+
+  </main>
+
+  <footer class="address-footer">
+    <p class="address-information">샛별배송 지역 중 배송불가 장소 안내</p>
+    <p class="address-cannot-list">관공서 / 학교 / 병원 / 시장 / 공단지역 / 산간지역 / 백화점 등</p>
+  </footer>
+
+
+
+  <div class="post_wrapper"></div>
+
+
+</body>
+</html>

--- a/src/pages/address/index.js
+++ b/src/pages/address/index.js
@@ -12,54 +12,38 @@ const researchButton = document.querySelector('.address-research');
 const openSearchAddress = () => {
   new daum.Postcode({
       oncomplete: function(data) {
-          // 검색결과 항목을 클릭했을때 실행할 코드를 작성하는 부분.
+          let addr = '';
+          let extraAddr = '';
 
-          // 각 주소의 노출 규칙에 따라 주소를 조합한다.
-          // 내려오는 변수가 값이 없는 경우엔 공백('')값을 가지므로, 이를 참고하여 분기 한다.
-          let addr = ''; // 주소 변수
-          let extraAddr = ''; // 참고항목 변수
-
-          //사용자가 선택한 주소 타입에 따라 해당 주소 값을 가져온다.
-          if (data.userSelectedType === 'R') { // 사용자가 도로명 주소를 선택했을 경우
+          if (data.userSelectedType === 'R') { 
               addr = data.roadAddress;
-          } else { // 사용자가 지번 주소를 선택했을 경우(J)
+          } else { 
               addr = data.jibunAddress;
           }
 
-          // 사용자가 선택한 주소가 도로명 타입일때 참고항목을 조합한다.
           if(data.userSelectedType === 'R'){
-              // 법정동명이 있을 경우 추가한다. (법정리는 제외)
-              // 법정동의 경우 마지막 문자가 "동/로/가"로 끝난다.
               if(data.bname !== '' && /[동|로|가]$/g.test(data.bname)){
                   extraAddr += data.bname;
               }
-              // 건물명이 있고, 공동주택일 경우 추가한다.
               if(data.buildingName !== '' && data.apartment === 'Y'){
                   extraAddr += (extraAddr !== '' ? ', ' + data.buildingName : data.buildingName);
               }
-              // 표시할 참고항목이 있을 경우, 괄호까지 추가한 최종 문자열을 만든다.
               if(extraAddr !== ''){
                   extraAddr = ' (' + extraAddr + ')';
               }
-              // 조합된 참고항목을 해당 필드에 넣는다.
               address.value = extraAddr;
           
           } else {
             address.value = '';
           }
 
-          // 우편번호와 주소 정보를 해당 필드에 넣는다.
           zip_code.value = data.zonecode;
           address.value = `${addr} (${data.buildingName})`;
-          // 커서를 상세주소 필드로 이동한다.
           detailAddress.focus();
 
-          // iframe을 넣은 element를 안보이게 한다.
-          // (autoClose:false 기능을 이용한다면, 아래 코드를 제거해야 화면에서 사라지지 않는다.)
           element_wrap.style.display = 'none';
 
       },
-      // 우편번호 찾기 화면 크기가 조정되었을때 실행할 코드를 작성하는 부분. iframe을 넣은 element의 높이값을 조정한다.
       onresize : function(size) {
           element_wrap.style.height = size.height+'px';
       },
@@ -67,7 +51,6 @@ const openSearchAddress = () => {
       height : '100%'
   }).embed(element_wrap);
 
-  // iframe을 넣은 element를 보이게 한다.
   element_wrap.style.display = 'block';
 }
 

--- a/src/pages/address/index.js
+++ b/src/pages/address/index.js
@@ -1,3 +1,4 @@
+import { setStorage } from '/src/lib';
 import '/src/styles/style.scss';
 
 const element_wrap = document.querySelector('.post_wrapper');
@@ -5,6 +6,8 @@ const zip_code = document.querySelector('#selected-zipcode')
 const address = document.querySelector('#selected-address');
 const detailAddress = document.querySelector('#address-detail');
 
+const saveButton = document.querySelector('.address-save');
+const researchButton = document.querySelector('.address-research');
 
 const openSearchAddress = () => {
   new daum.Postcode({
@@ -47,7 +50,7 @@ const openSearchAddress = () => {
 
           // 우편번호와 주소 정보를 해당 필드에 넣는다.
           zip_code.value = data.zonecode;
-          address.value = addr;
+          address.value = `${addr} (${data.buildingName})`;
           // 커서를 상세주소 필드로 이동한다.
           detailAddress.focus();
 
@@ -68,6 +71,16 @@ const openSearchAddress = () => {
   element_wrap.style.display = 'block';
 }
 
+
+const handleSaveAddress = () => {
+
+  setStorage('address', `{"zip_code":"${zip_code.value}","address":"${address.value}","detail-address":"${detailAddress.value}"}`)
+  .then(
+    self.close()
+  );
+}
+
 openSearchAddress();
 
-// savebutton.addEventListener('click', setAddressToLocalStorage)
+saveButton.addEventListener('click', handleSaveAddress)
+researchButton.addEventListener('click', openSearchAddress);

--- a/src/pages/address/index.js
+++ b/src/pages/address/index.js
@@ -1,0 +1,73 @@
+import '/src/styles/style.scss';
+
+const element_wrap = document.querySelector('.post_wrapper');
+const zip_code = document.querySelector('#selected-zipcode')
+const address = document.querySelector('#selected-address');
+const detailAddress = document.querySelector('#address-detail');
+
+
+const openSearchAddress = () => {
+  new daum.Postcode({
+      oncomplete: function(data) {
+          // 검색결과 항목을 클릭했을때 실행할 코드를 작성하는 부분.
+
+          // 각 주소의 노출 규칙에 따라 주소를 조합한다.
+          // 내려오는 변수가 값이 없는 경우엔 공백('')값을 가지므로, 이를 참고하여 분기 한다.
+          let addr = ''; // 주소 변수
+          let extraAddr = ''; // 참고항목 변수
+
+          //사용자가 선택한 주소 타입에 따라 해당 주소 값을 가져온다.
+          if (data.userSelectedType === 'R') { // 사용자가 도로명 주소를 선택했을 경우
+              addr = data.roadAddress;
+          } else { // 사용자가 지번 주소를 선택했을 경우(J)
+              addr = data.jibunAddress;
+          }
+
+          // 사용자가 선택한 주소가 도로명 타입일때 참고항목을 조합한다.
+          if(data.userSelectedType === 'R'){
+              // 법정동명이 있을 경우 추가한다. (법정리는 제외)
+              // 법정동의 경우 마지막 문자가 "동/로/가"로 끝난다.
+              if(data.bname !== '' && /[동|로|가]$/g.test(data.bname)){
+                  extraAddr += data.bname;
+              }
+              // 건물명이 있고, 공동주택일 경우 추가한다.
+              if(data.buildingName !== '' && data.apartment === 'Y'){
+                  extraAddr += (extraAddr !== '' ? ', ' + data.buildingName : data.buildingName);
+              }
+              // 표시할 참고항목이 있을 경우, 괄호까지 추가한 최종 문자열을 만든다.
+              if(extraAddr !== ''){
+                  extraAddr = ' (' + extraAddr + ')';
+              }
+              // 조합된 참고항목을 해당 필드에 넣는다.
+              address.value = extraAddr;
+          
+          } else {
+            address.value = '';
+          }
+
+          // 우편번호와 주소 정보를 해당 필드에 넣는다.
+          zip_code.value = data.zonecode;
+          address.value = addr;
+          // 커서를 상세주소 필드로 이동한다.
+          detailAddress.focus();
+
+          // iframe을 넣은 element를 안보이게 한다.
+          // (autoClose:false 기능을 이용한다면, 아래 코드를 제거해야 화면에서 사라지지 않는다.)
+          element_wrap.style.display = 'none';
+
+      },
+      // 우편번호 찾기 화면 크기가 조정되었을때 실행할 코드를 작성하는 부분. iframe을 넣은 element의 높이값을 조정한다.
+      onresize : function(size) {
+          element_wrap.style.height = size.height+'px';
+      },
+      width : '100%',
+      height : '100%'
+  }).embed(element_wrap);
+
+  // iframe을 넣은 element를 보이게 한다.
+  element_wrap.style.display = 'block';
+}
+
+openSearchAddress();
+
+// savebutton.addEventListener('click', setAddressToLocalStorage)

--- a/src/pages/products/index.html
+++ b/src/pages/products/index.html
@@ -48,10 +48,12 @@
           </div>
     
           <div class="menu_link">
-            <button type="button" aria-label="배송지"></button>
-            <button type="button" aria-label="찜하기"></button>
-            <a href="/src/pages/cart/" role="button" aria-label="장바구니"></a>
+            <button type="button" aria-label="배송지" class="menu_link__address"></button>
+            <button type="button" aria-label="찜하기" class="menu_link__like"></button>
+            <a href="/src/pages/cart/" role="button" aria-label="장바구니" class="menu_link__cart"></a>
+
           </div>
+          
         </div>
       </div>      
 

--- a/src/pages/products/index.js
+++ b/src/pages/products/index.js
@@ -1,4 +1,4 @@
-import { fixHeader } from '/src/lib';
+import { initHeader } from '/src/lib';
 import '/src/styles/style.scss';
 
-fixHeader();
+initHeader();

--- a/src/styles/layout/_header.scss
+++ b/src/styles/layout/_header.scss
@@ -189,33 +189,87 @@
 .menu_link {
   @include flex-container(row items-center);
   @include gap(20);
+  @include relative();
 
-  & > button {
+  %menu_link-icon {
     @include size(36px, 36px);
-    background: transparent;
+    background-color: white;
     border: none;
+  }
     
-    &:nth-child(1) {
-      background: url('/images/menu/menulink-Icon.svg') no-repeat 0 50%;
-      &:hover {
-        background: url('/images/menu/menulink-Icon-hover.svg') no-repeat 0 50%;
-      }
-    }
-    &:nth-child(2) {
-      background: url('/images/menu/menulink-Icon.svg') no-repeat 50% 50%;
-      &:hover {
-        background: url('/images/menu/menulink-Icon-hover.svg') no-repeat 50% 50%;
-      }
+  &__address {
+    @extend %menu_link-icon;
+    background: url('/images/menu/menulink-Icon.svg') no-repeat 0 50%;
+    &:hover {
+      background: url('/images/menu/menulink-Icon-hover.svg') no-repeat 0 50%;
     }
   }
-
-  & a {
-    @include size(36px, 36px);
+  &__like {
+    @extend %menu_link-icon;
+    background: url('/images/menu/menulink-Icon.svg') no-repeat 50% 50%;
+    &:hover {
+      background: url('/images/menu/menulink-Icon-hover.svg') no-repeat 50% 50%;
+    }
+  }
+  
+  &__cart {
+    @extend %menu_link-icon;
     background: url('/images/menu/menulink-Icon.svg') no-repeat 100% 50%;
     &:hover {
       background: url('/images/menu/menulink-Icon-hover.svg') no-repeat 100% 50%;
     }
   }
+
+
+  &__address-box {
+    @include absolute(t 55 r 0);
+    @include px(17px);
+    @include py(18px 17px);
+    @include size(267px);
+
+    border: 1px solid $gray100;
+    background-color: white;
+
+    & p {
+      @include font(size 1.17rem weight 300 lh 1.6);
+
+      & strong {
+        color: $primary;
+      }
+    }
+
+    &--container {
+      @include flex-container(row items-center);
+      @include justify-content(between);
+      @include my(10px 0);
+
+      & a {
+        @include flex-container(row items-center);
+        @include justify-content(center);
+        @include size(80px, 36px);
+        @include rounded(sm);
+        @include font(weight 600);
+        @include px(10);
+        
+        border: 1px solid $primary;
+        color: $primary
+        
+      }
+
+      & .address-box-search {
+        @include size(135px, 36px);
+        @include rounded(sm);
+        @include font(weight 400);
+
+        background-color: $primary;
+        color: white;
+        border: none;
+
+      }
+    }
+
+    
+  }  
 }
 
 .menu {

--- a/src/styles/layout/_header.scss
+++ b/src/styles/layout/_header.scss
@@ -236,6 +236,11 @@
       & strong {
         color: $primary;
       }
+
+      &.deliver_type {
+        @include font(size 1.1rem weight 400);
+        color: $primary;
+      }
     }
 
     &--container {
@@ -265,6 +270,15 @@
         color: white;
         border: none;
 
+        &.research {
+          @include size(100%, 36px);
+          @include rounded(sm);
+          @include font(size 0.9rem weight 600);
+  
+          background-color: white;
+          color: $primary;
+          border: 1px solid $primary;
+        }
       }
     }
 

--- a/src/styles/pages/_address.scss
+++ b/src/styles/pages/_address.scss
@@ -1,0 +1,101 @@
+@use '/src/styles/base' as *;
+@use '/src/styles/abstracts' as *;
+
+
+.address-header {
+  @include py(50);
+  @include mx(auto);
+  @include size(100vw);
+  text-align: center;
+
+  & h1 {
+    @include font(size 1.7rem weight 500);
+    
+    & strong {
+      color: $primary;
+    }
+  }
+
+  & h3 {
+    @include font(weight 500 lh 1.6);
+    color: $gray500;
+
+  }
+}
+
+.address-main {
+  @include size(100vw);
+  @include px(30);
+  @include mx(auto);
+
+  & .address-result {
+    @include flex-container(row items-center);
+    @include justify-content(between);
+    @include py(0 10);
+    @include gap(10);
+
+    & input[type="text"] {
+      @include size(70%, 44px);
+      @include px(10);
+      @include rounded(sm);
+
+      outline: none;
+      border: 1px solid $gray200;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+
+    & .address-research {
+      @include size(30%, 44px);
+      @include font(weight 600);
+      @include rounded(sm);
+      background-color: white;
+      border: 1px solid $primary;
+      color: $primary;
+    }
+  }
+
+  & .address-detail {
+    @include size(100%, 44px);
+    @include px(10);
+    @include rounded(sm);
+    @include my(0 15);
+    border: 1px solid $gray200;
+  }
+
+  & .delete-address-info {
+    @include font(size 0.9rem weight 500);
+    @include my(0 20);
+    color: $gray400;
+  }
+
+  & .address-save {
+    @include size(100%, 44px);
+    @include px(10);
+    @include rounded(sm);
+    @include my(0 35);
+    @include font(size 1.1rem weight 500);
+    border: none;
+    background-color: $primary;
+    color: white;
+  }
+}
+
+.address-footer {
+  @include size(100vw);
+  @include px(30);
+  @include mx(auto);
+  @include font(size 14px weight 400 lh 15px);
+
+  & .address-information {
+    color: rgb(240, 63, 64);
+  }
+}
+
+.post_wrapper {
+  @include absolute(t 0 l 0);
+  @include size(100vw, 100% !important);
+  z-index: 10;
+  background: white;
+
+}

--- a/src/styles/pages/_index.scss
+++ b/src/styles/pages/_index.scss
@@ -4,3 +4,4 @@
 @forward './products';
 @forward './register';
 @forward './main';
+@forward './address';


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| --------------- |
|![feat#37 address_setting](https://github.com/FRONTENDSCHOOL8/super-market/assets/46062634/ac6d63b2-d940-4967-b14a-8fe64d854213)|


### 📝 Details

- 배송지 버튼 클릭 시의 정보 창 마크업 및 스타일링
- 주소 검색 버튼 클릭 시 다음 주소 검색 api를 활용한 주소 검색창 팝업
- 주소 검색 팝업창 마크업 및 스타일링
- 재검색 기능 구현
- 검색한 주소를 로컬스토리지에 저장하는 기능 구현
- 로컬스토리지에 주소 정보가 있다면 배송지 버튼의 렌더링을 다르게 보여주는 기능 구현
- 로컬스토리지에 주소가 있어도 재등록 할 수 있는 기능 구현
- 추후 로그인 기능 구현 시 로그인한 사용자의 주소를 가져올 수 있도록 추가 구현 필요
- 이 pr이 merge 된 이후 각 js파일의 `fixHeader`를 `initHeader`로 변경 및 product/index.html의 header를 재 붙여넣어야 정상 작동함.
