### PR TITLE
Feat/kina/#61 디테일페이지 네비게이션바 동작 구현

### DIFF
--- a/src/pages/detail/index.html
+++ b/src/pages/detail/index.html
@@ -255,7 +255,7 @@
       </div>
       <nav class="detail-navigation">
         <ul class="detail-navigation-list">
-          <li class="is--active">
+          <li>
             <a href="#description">상품설명</a>
           </li>
           <li>
@@ -265,7 +265,7 @@
           <li><a href="#qna">문의</a></li>
         </ul>
       </nav>
-      <article class="product-description" id="description">
+      <article class="product-description nav-item" id="description">
         <img
           class=""
           src="/images/product/product01-description.png"
@@ -284,7 +284,10 @@
           </p>
         </div>
       </article>
-      <article class="product-detail-description" id="detail-description">
+      <article
+        class="product-detail-description nav-item"
+        id="detail-description"
+      >
         <img
           src="/images/product/product01-detail.png"
           alt="탱탱쫄면 크기비교 및 영양정보"
@@ -294,7 +297,7 @@
         </div>
       </article>
 
-      <section class="board" id="review">
+      <section class="board nav-item" id="review">
         <h3>상품후기</h3>
         <em>글후기 50원 적립금 혜택이 있어요.</em>
         <ul class="post-guide">
@@ -382,7 +385,7 @@
         </div>
       </section>
 
-      <section class="board" id="qna">
+      <section class="board nav-item" id="qna">
         <h3>상품문의</h3>
         <ul class="post-guide">
           <li>

--- a/src/pages/detail/index.js
+++ b/src/pages/detail/index.js
@@ -61,13 +61,14 @@ const handleDetailNav = () => {
       if (entry.isIntersecting) {
         let currentItemId = entry.target.id;
 
-        detailNavMenu.forEach((element) => {
+        const setLinkById = (element) => {
           element.classList.toggle(
             'is--active',
             element.firstElementChild.getAttribute('href') ===
               `#${currentItemId}`
           );
-        });
+        };
+        detailNavMenu.forEach(setLinkById);
       }
     });
   });

--- a/src/pages/detail/index.js
+++ b/src/pages/detail/index.js
@@ -1,5 +1,5 @@
 import '/src/styles/style.scss';
-import { getNode, initHeader, comma } from '/src/lib';
+import { getNode, getNodes, initHeader, comma } from '/src/lib';
 
 initHeader();
 
@@ -10,6 +10,8 @@ const countIncrease = getNode('.increase');
 const productCount = getNode('.count');
 const optionPrice = getNode('.product-option-price');
 const totalPrice = getNode('.product-total-price');
+const detailNavMenu = getNodes('.detail-navigation-list li');
+const navItem = getNodes('.nav-item');
 
 let isClick;
 
@@ -51,7 +53,32 @@ const showTotalPrice = () => {
   return (totalPrice.innerText = comma(productPrice * productCount.value));
 };
 
+const handleDetailNav = () => {
+  if (!navItem) return;
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        let currentItemId = entry.target.id;
+
+        detailNavMenu.forEach((element) => {
+          element.classList.toggle(
+            'is--active',
+            element.firstElementChild.getAttribute('href') ===
+              `#${currentItemId}`
+          );
+        });
+      }
+    });
+  });
+
+  navItem.forEach((section) => {
+    observer.observe(section);
+  });
+};
+
 zzimButton.addEventListener('click', handleLike);
 notifyButton.addEventListener('click', handleNotify);
 countDecrease.addEventListener('click', handleCount);
 countIncrease.addEventListener('click', handleCount);
+window.addEventListener('scroll', handleDetailNav);

--- a/src/styles/pages/_detail.scss
+++ b/src/styles/pages/_detail.scss
@@ -175,7 +175,7 @@
 }
 
 .detail-navigation {
-  @include sticky(t 0 z 10);
+  @include sticky(t 72 z 2);
 
   &-list {
     @include flex-container(row space-around);
@@ -195,7 +195,7 @@
       @include font(size $labelMedium);
     }
 
-    .is--active {
+    &.is--active {
       background-color: $white;
       border-bottom: none;
 


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| --------------- |
![scroll](https://github.com/FRONTENDSCHOOL8/super-market/assets/148828856/01f1fb41-6217-41ca-9269-c0d8223f5318)

### 📝 Details

- IntersectionObserver 사용하여 스크롤에 따라 동작 구현
   1. 스크롤 시 nav-item 의 화면 진입을 확인
   2. 해당 nav-item의 id값을 반환
   3. id과 일치하는 href를 가진 li > a 에 스타일 변화를 줌

### 고쳐야할 점
- 헤더와 네비게이션때문에 디테일 네비게이션에서 메뉴를 선택해서 이동했을때 이미지의 상단이 가려지는 이슈가 있음.
- 디테일 네비게이션은 sticky를 이용하여 고정해두었기 때문에 어떻게 해야할지 생각해봐야 할것 같습니다.
