### PR TITLE
Modify(feat/ryu/#64): 장바구니 아이콘에서의 문제 해결

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,6 @@ import {
   insertAfter,
   insertBefore,
   openCartModal,
-  handleProduct,
   hideElementNoExist,
   updateRecentlyViewedProducts,
 } from '/src/lib';
@@ -100,4 +99,3 @@ popupNotToday.addEventListener('click', handleWatchTodayButton);
 
 recommendProductList.addEventListener('click', openCartModal);
 discountProductList.addEventListener('click', openCartModal);
-recommendProductList.addEventListener('click', handleProduct);

--- a/src/lib/components/cartModal.js
+++ b/src/lib/components/cartModal.js
@@ -142,7 +142,10 @@ const handleProductCount = (countElement, target) => {
 export const openCartModal = (e) => {
   const currentTarget = e ? e.target.closest('.cart') : null;
   if (currentTarget) e.preventDefault();
-  else return;
+  else {
+    handleProduct(e);
+    return;
+  }
 
   const product = e.target.closest('.product');
   const cartData = extractCartData(product);

--- a/src/styles/components/_cartModal.scss
+++ b/src/styles/components/_cartModal.scss
@@ -48,8 +48,8 @@
     color: $content;
   }
 }
-
-.cart-product {
+// shopping basket
+.basket-product {
   @include size(100vw, 100vh);
   @include absolute();
   @include flex-container(items-center justify-center);


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| --------------- |
|                 |

### 📝 Details

- 장바구니 아이콘 클릭 시 디테일 페이지로 이동하는 것을 막고, 장바구니 모달이 나타나도록 수정했습니다.
- 장바구니 모달과 장바구니 페이지의 클래스명이 똑같아 생기는 문제는 장바구니 모달 클래스를 cart-product에서 basket-product로 수정했습니다.
