### PR TITLE
modify(feat/ryu/#74): 장바구니 페이지 마크업 및 스타일링 수정

### DIFF
--- a/src/pages/cart/index.html
+++ b/src/pages/cart/index.html
@@ -14,7 +14,6 @@
   <body>
     <header class="header">
       <div class="header__wrapper">
-
         <ul class="sign_menu">
           <li>
             <a href="/src/pages/register/" class="menu_join">회원가입</a>
@@ -40,24 +39,35 @@
               <button type="button" class="beauty-karly">뷰티칼리</button>
             </span>
           </div>
-    
+
           <div class="search_box">
             <form action="/src/pages/products/" method="POST">
-              <input type="text" placeholder="검색어를 입력해주세요"/>
+              <input type="text" placeholder="검색어를 입력해주세요" />
               <button type="button" class="erase"></button>
             </form>
             <button type="submit" class="search"></button>
           </div>
-    
-          <div class="menu_link">
-            <button type="button" aria-label="배송지" class="menu_link__address"></button>
-            <button type="button" aria-label="찜하기" class="menu_link__like"></button>
-            <a href="/src/pages/cart/" role="button" aria-label="장바구니" class="menu_link__cart"></a>
 
+          <div class="menu_link">
+            <button
+              type="button"
+              aria-label="배송지"
+              class="menu_link__address"
+            ></button>
+            <button
+              type="button"
+              aria-label="찜하기"
+              class="menu_link__like"
+            ></button>
+            <a
+              href="/src/pages/cart/"
+              role="button"
+              aria-label="장바구니"
+              class="menu_link__cart"
+            ></a>
           </div>
-          
         </div>
-      </div>      
+      </div>
 
       <nav class="menu">
         <div class="menu__category">
@@ -150,7 +160,6 @@
         </div>
         <a href="" class="menu__info"><em>샛별&middot;낮</em>배송안내</a>
       </nav>
-    
     </header>
     <main>
       <section class="cart__wrapper">
@@ -161,7 +170,8 @@
             <div class="select__all">
               <input type="checkbox" name="check-all" id="check-all" />
               <label for="check-all">전체선택(0/5)</label>
-              <span>선택삭제</span>
+              <div class="divider"></div>
+              <button class="select-delete">선택삭제</button>
             </div>
             <!-- start: cart-product-list -->
             <div class="cart-product-list">
@@ -189,9 +199,6 @@
                   <p class="cart-product__content">
                     <span class="cart-product__content__title">
                       [풀무원] 탱탱쫄면 (4개입)
-                    </span>
-                    <span class="cart-product__content__description">
-                      [압구정주꾸미] 인기 볶음 6종 (택1)
                     </span>
                   </p>
                   <div class="cart-product__count">
@@ -242,6 +249,7 @@
             <div class="select__all">
               <input type="checkbox" name="check-all" id="check-all" />
               <label for="check-all">전체선택(0/5)</label>
+              <div class="divider"></div>
               <span>선택삭제</span>
             </div>
           </div>

--- a/src/styles/pages/_cart.scss
+++ b/src/styles/pages/_cart.scss
@@ -1,14 +1,16 @@
 @use '/src/styles/abstracts' as *;
 body {
-  width: 100vw;
+  @include size(100vw);
 }
 .cart__wrapper {
   @include container-width(max, 1050px);
-  @include size(100%);
+  @include size(100%, 100%);
+  min-height: 710px;
   @include m(x auto y 80);
   h2 {
     text-align: center;
     font-size: $labelLarge;
+    margin-bottom: 44px;
   }
   input[type='checkbox'] {
     @include hide;
@@ -31,28 +33,33 @@ body {
   @include size(100%);
   @include flex-container(column item-center);
   @include gap(16);
-  margin-top: 60px;
   .select__all {
-    @include size(100%);
+    @include size(100%, 20px);
+    @include gap(10px);
+    display: flex;
     align-items: center;
     color: $content;
+    input[type='checkbox'] {
+      @include hide;
+    }
     input[type='checkbox'] + label {
+      @include relative();
       padding-left: 30px;
-      padding-top: 7px;
+      padding-top: 6px;
     }
-    label {
-      border-right: 1px solid $gray100;
-      padding-right: 8px;
+    .divider {
+      @include size(1px, 100%);
+      display: block;
+      background-color: $gray100;
     }
-    span {
-      padding-left: 8px;
-      padding-top: 4px;
-      cursor: pointer;
+    .select-delete {
+      padding-top: 6px;
+      border: 0;
+      background-color: transparent;
     }
   }
 }
 .cart-product-list {
-  background-color: white;
   .cart-product__wrapper {
     &__bar {
       @include size(100%);
@@ -119,9 +126,8 @@ body {
       }
       &__change,
       &__result {
-        width: 100%;
+        @include size(100%, 30px);
         max-width: 30px;
-        height: 30px;
         line-height: 30px;
       }
     }
@@ -155,7 +161,6 @@ body {
   }
 }
 .information__wrapper {
-  background-color: $white;
   @include size(100%);
   max-width: 280px;
   margin-left: 20px;
@@ -220,7 +225,6 @@ body {
     @include flex-container(row items-center);
 
     @include justify-content(between);
-    // justify-content: space-between;
     &__description {
       @include font(size $paraGraphMedium);
       color: $content;
@@ -257,8 +261,12 @@ body {
   border: none;
   border-radius: 4px;
 }
+.order-button:disabled {
+  background-color: $gray300;
+}
 .detail {
   @include font(size $labelSmall);
+  max-width: 280px;
   color: $gray400;
   li {
     line-height: 1.5;


### PR DESCRIPTION
### 🖼️ Screen shot

|전 | 후 |
| --------------- |------ |
|      ![스크린샷 2024-01-11 오후 4 23 52](https://github.com/FRONTENDSCHOOL8/super-market/assets/91606951/9548d06c-62af-4be3-8500-33076ab826b0)       |  ![스크린샷 2024-01-11 오후 5 20 56](https://github.com/FRONTENDSCHOOL8/super-market/assets/91606951/fb048160-3f20-4623-b0eb-7076963241df)|
|     ![스크린샷 2024-01-11 오후 4 23 46](https://github.com/FRONTENDSCHOOL8/super-market/assets/91606951/b460589e-2f62-41cb-8359-a24ae3e37389)     |    ![스크린샷 2024-01-11 오후 5 20 53](https://github.com/FRONTENDSCHOOL8/super-market/assets/91606951/77bbb1c9-8eee-4169-9a5b-f367f8fcc5aa)          |

### 📝 Details

- '전체 선택'과 '선택 삭제' 사이에 divider 추가
- '주문하기' 버튼에 disable 상태 추가
- 상세설명 width 지정
