### PR TITLE
modify(feat/sang/#89): 주소 검색창 팝업 함수 라이브러리로 구현

### DIFF
--- a/src/lib/components/address.js
+++ b/src/lib/components/address.js
@@ -1,0 +1,22 @@
+
+
+export const setSearchAddressEvent = (target, callback) => {
+  target.addEventListener('click', handleSetAddress(callback));
+}
+
+const handleSetAddress = (callback) => {
+
+  return () => {
+    const width = 502;
+    const height = 547;
+    const popupX = (screen.width / 2) - (width / 2);
+    const popupY = (screen.height / 2) - (height / 2);
+    window.open('/src/pages/address/', '_blank', `width=${width},height=${height},left=${popupX},top=${popupY}`);
+    
+    if(callback) callback();
+
+  }
+
+
+}
+

--- a/src/lib/components/header.js
+++ b/src/lib/components/header.js
@@ -1,4 +1,4 @@
-import { insertLast, getNode, getStorage } from '/src/lib';
+import { setSearchAddressEvent, getNode, getStorage, promiseInsertLast } from '/src/lib';
 
 const header = document.querySelector('.header');
 const headerMenubar = document.querySelector('.menu');
@@ -21,26 +21,9 @@ const handleScrollHeader = e => {
   }
 }
 
-const handleSetAddress = () => {
-  const width = 502;
-  const height = 547;
-  const popupX = (screen.width / 2) - (width / 2);
-  const popupY = (screen.height / 2) - (height / 2);
-  window.open('/src/pages/address/', '_blank', `width=${width},height=${height},left=${popupX},top=${popupY}`);
-  isShowAddressBox = !isShowAddressBox;
-  menuLink.removeChild(getNode('.menu_link__address-box'))
-}
 
-const promiseInsertLast = (target, template) => {
 
-  return new Promise((resolve, reject) => {
-    resolve(insertLast(target, template))
-  });
-}
 
-const setSearchAddressEvent = (target) => {
-  target.addEventListener('click', handleSetAddress)
-}
 
 const handleAddressBox = async () => {
   let template;
@@ -71,9 +54,15 @@ const handleAddressBox = async () => {
   }
 
   if(!isShowAddressBox) {
+    const closeAddressBox = () => {
+      isShowAddressBox = !isShowAddressBox;
+      menuLink.removeChild(getNode('.menu_link__address-box'))
+    }
+
     isShowAddressBox = !isShowAddressBox;
     promiseInsertLast(menuLink, template)
-    .then(setSearchAddressEvent(getNode('.address-box-search')))
+    .then(setSearchAddressEvent(getNode('.address-box-search'), closeAddressBox));
+    
   } else {
     isShowAddressBox = !isShowAddressBox;
     menuLink.removeChild(getNode('.menu_link__address-box'));

--- a/src/lib/components/index.js
+++ b/src/lib/components/index.js
@@ -7,3 +7,4 @@ export * from './recentBar.js';
 export * from './validationInput.js';
 export * from './clickBtnMoveToSite.js';
 export * from './productCard.js';
+export * from './address.js';

--- a/src/lib/dom/insert.js
+++ b/src/lib/dom/insert.js
@@ -28,3 +28,10 @@ export function insertAfter(node,text){
 
   node.insertAdjacentHTML('afterend',text)
 }
+
+export const promiseInsertLast = (target, template) => {
+
+  return new Promise((resolve, reject) => {
+    resolve(insertLast(target, template))
+  });
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
         register: resolve(__dirname, 'src/pages/register/index.html'),
         detail: resolve(__dirname, 'src/pages/detail/index.html'),
         cart: resolve(__dirname, 'src/pages/cart/index.html'),
+        address: resolve(__dirname, 'src/pages/address/index.html'),
       },
     },
   },


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| --------------- |
```js
export const setSearchAddressEvent = (target, callback) => {
  target.addEventListener('click', handleSetAddress(callback));
}

const handleSetAddress = (callback) => {
  return () => {
    const width = 502;
    const height = 547;
    const popupX = (screen.width / 2) - (width / 2);
    const popupY = (screen.height / 2) - (height / 2);
    window.open('/src/pages/address/', '_blank', `width=${width},height=${height},left=${popupX},top=${popupY}`);
    
    if(callback) callback();
  }
}
```

### 📝 Details

- 배송지 저장 / 검색 등 기능을 원하는 버튼에 배송지 검색 팝업을 띄우는 라이브러리 함수 생성
- 이벤트에 추가로 기능이 있다면 callback함수로 전달
    - 예시) 헤더에서는 주소검색 버튼을 클릭 후 배송지 안내 영역이 제거되어야 하므로, 
      안내 영역을 제거하는 함수를 콜백으로 전달했음.
    ```setSearchAddressEvent(getNode('.address-box-search'), closeAddressBox)```
