### PR TITLE
feat(feat/ryu/#88): 메인페이지 상품 리스트

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     />
   </head>
   <body>
+    <!-- start: header -->
     <header class="header">
       <div class="header__wrapper">
         <ul class="sign_menu">
@@ -162,6 +163,7 @@
         <a href="" class="menu__info"><em>샛별&middot;낮</em>배송안내</a>
       </nav>
     </header>
+    <!-- start: main -->
     <main>
       <div class="banner">
         <div class="banner__cover swiper-container">
@@ -189,254 +191,30 @@
           <button class="banner__button swiper-button-next"></button>
         </div>
       </div>
-      <!-- start: recommend-products -->
       <section class="recommend-products">
         <h2>이 상품 어때요?</h2>
         <div class="product-list swiper-container">
-          <div class="product-list__wrapper swiper-wrapper">
-            <!-- start: product1 -->
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product01.png"
-                  class="product__images__thumbnail"
-                  alt="탱탱쫄면 봉지 4개입"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__title">[풀무원] 탱탱쫄면 (4개입)</span>
-              <p class="product__discount">
-                <span class="product__price">4,980원</span>
-              </p>
-            </a>
-            <!-- start: product2 -->
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product02.png"
-                  class="product__images__thumbnail"
-                  alt="노란색 죠르디 선쿠션과 붉은 하트 선글라스 자석"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__brand">
-                [온더바디] 죠르디 시카 자석 선쿠션
-              </span>
-              <span class="product__title">
-                [온더바디] 죠르디 시카 자석 선쿠션
-              </span>
-              <p class="product__discount">
-                <span class="product__discount-rate">24%</span>
-                <span class="product__price">32,500원</span>
-              </p>
-              <span class="product__regular-price">24,000원</span>
-              <span class="product__description">
-                CJ즉석밥 고소한 맛의 발아 현미밥
-              </span>
-              <p class="product__keyword-list">
-                <span class="product__keyword only">Karly Only</span>
-                <span class="product__keyword">한정수량</span>
-              </p>
-            </a>
-            <!-- start: product3 -->
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product03.png"
-                  class="product__images__thumbnail"
-                  alt="지퍼백에 들어있는 현미 4kg"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__title"> 유기농 밀키퀸 현미 4kg </span>
-              <p class="product__discount">
-                <span class="product__price">25,000원</span>
-              </p>
-            </a>
-            <!-- start: product4 -->
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product04.png"
-                  class="product__images__thumbnail"
-                  alt="분무기와 통에 든 세탁세제 1.5리터"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__title">[프로쉬] 베이비 세탁세제</span>
-              <p class="product__discount">
-                <span class="product__discount-rate">24%</span>
-                <span class="product__price">18,900원</span>
-              </p>
-              <span class="product__regular-price">24,000원</span>
-            </a>
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product01.png"
-                  class="product__images__thumbnail"
-                  alt="탱탱쫄면 봉지 4개입"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__title">[풀무원] 탱탱쫄면 (4개입)</span>
-              <p class="product__discount">
-                <span class="product__price">4,980원</span>
-              </p>
-            </a>
-          </div>
+          <div class="product-list__wrapper swiper-wrapper"></div>
           <button class="product__button left swiper-button-prev"></button>
           <button class="product__button right swiper-button-next"></button>
         </div>
       </section>
-      <!-- start: line-banner -->
       <div class="line-banner">
         <figure>
           <img src="./src/assets/main/line-banner.png" />
           <figcaption>퍼플 위크 광고, 더 높은 적립과 3종 쿠폰팩</figcaption>
         </figure>
       </div>
-      <!-- start: discount-products -->
       <section class="discount-products">
         <h2>놓치면 후회할 가격</h2>
         <div class="product-list swiper-container">
-          <div class="product-list__wrapper swiper-wrapper">
-            <!-- start: product1 -->
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product01.png"
-                  class="product__images__thumbnail"
-                  alt="탱탱쫄면 봉지 4개입"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__title">[풀무원] 탱탱쫄면 (4개입)</span>
-              <p class="product__discount">
-                <span class="product__price">4,980원</span>
-              </p>
-            </a>
-            <!-- start: product2 -->
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product02.png"
-                  class="product__images__thumbnail"
-                  alt="노란색 죠르디 선쿠션과 붉은 하트 선글라스 자석"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__brand">
-                [온더바디] 죠르디 시카 자석 선쿠션
-              </span>
-              <span class="product__title">
-                [온더바디] 죠르디 시카 자석 선쿠션
-              </span>
-              <p class="product__discount">
-                <span class="product__discount-rate">24%</span>
-                <span class="product__price">32,500원</span>
-              </p>
-              <span class="product__regular-price">24,000원</span>
-              <span class="product__description">
-                CJ즉석밥 고소한 맛의 발아 현미밥
-              </span>
-              <p class="product__keyword-list">
-                <span class="product__keyword only">Karly Only</span>
-                <span class="product__keyword">한정수량</span>
-              </p>
-            </a>
-            <!-- start: product3 -->
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product03.png"
-                  class="product__images__thumbnail"
-                  alt="지퍼백에 들어있는 현미 4kg"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__title"> 유기농 밀키퀸 현미 4kg </span>
-              <p class="product__discount">
-                <span class="product__price">25,000원</span>
-              </p>
-            </a>
-            <!-- start: product4 -->
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product04.png"
-                  class="product__images__thumbnail"
-                  alt="분무기와 통에 든 세탁세제 1.5리터"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__title">[프로쉬] 베이비 세탁세제</span>
-              <p class="product__discount">
-                <span class="product__discount-rate">24%</span>
-                <span class="product__price">18,900원</span>
-              </p>
-              <span class="product__regular-price">24,000원</span>
-            </a>
-            <a href="/src/pages/detail/" class="product swiper-slide">
-              <div class="product__images">
-                <img
-                  src="./src/assets/main/product01.png"
-                  class="product__images__thumbnail"
-                  alt="탱탱쫄면 봉지 4개입"
-                />
-                <img
-                  src="./public/images/menu/cart.svg"
-                  alt="장바구니에 담기"
-                  class="cart"
-                />
-              </div>
-              <span class="product__title">[풀무원] 탱탱쫄면 (4개입)</span>
-              <p class="product__discount">
-                <span class="product__price">4,980원</span>
-              </p>
-            </a>
-          </div>
+          <div class="product-list__wrapper swiper-wrapper"></div>
           <button class="product__button left swiper-button-prev"></button>
           <button class="product__button right swiper-button-next"></button>
         </div>
       </section>
     </main>
+    <!-- start: recently_product -->
     <aside class="recently">
       <span class="recently__title">최근 본 상품</span>
       <div class="recently__cover swiper-container">
@@ -451,6 +229,7 @@
         ></button>
       </div>
     </aside>
+    <!-- start: popup -->
     <div class="popup">
       <div class="popup__wrapper">
         <img
@@ -464,6 +243,7 @@
         </div>
       </div>
     </div>
+    <!-- start: footer -->
     <footer class="footer">
       <div class="footer__wrapper">
         <div class="footer__wrapper--info">

--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+import pb from '/src/lib/api/pocketbase';
 import './src/styles/style.scss';
 import {
   initHeader,
@@ -11,6 +12,7 @@ import {
   openCartModal,
   hideElementNoExist,
   updateRecentlyViewedProducts,
+  createCardTemplate,
 } from '/src/lib';
 
 const popupCloseButton = getNode('.popup .close');
@@ -90,12 +92,30 @@ const handleWatchTodayButton = () => {
   isHidePopup();
 };
 
+const showProductCard = async (target) => {
+  const productData = await pb.collection('products').getFullList({});
+  const promises = productData.slice(0, 16).map((product) => {
+    const template = createCardTemplate(product);
+    return insertLast(target, template);
+  });
+};
+
+const handleShowProductList = async () => {
+  const recommendProduct = getNode(
+    '.recommend-products .product-list__wrapper'
+  );
+  const discountProduct = getNode('.discount-products .product-list__wrapper');
+
+  await showProductCard(recommendProduct);
+  await showProductCard(discountProduct);
+  recommendProductList.addEventListener('click', openCartModal);
+  discountProductList.addEventListener('click', openCartModal);
+};
+
 initHeader();
 isHidePopup();
 hideElementNoExist();
 
 popupCloseButton.addEventListener('click', closePopup);
 popupNotToday.addEventListener('click', handleWatchTodayButton);
-
-recommendProductList.addEventListener('click', openCartModal);
-discountProductList.addEventListener('click', openCartModal);
+document.addEventListener('DOMContentLoaded', handleShowProductList());

--- a/src/lib/components/cartModal.js
+++ b/src/lib/components/cartModal.js
@@ -35,6 +35,7 @@ const findDataObj = {
     result: '',
   },
 };
+
 const getPriceNumber = (string) => Number(string.replace(/[원,]/g, ''));
 const getPriceString = (number) => `${number.toLocaleString()}원`;
 const switchPrice = (string, point) => {
@@ -115,7 +116,7 @@ const generateTemplate = (
           <p class="basket-product__grade">
             <span class="basket-product__grade__type">적립</span>
             <span class="basket-product__grade__description"
-              >구매 시 ${point} 적립</span
+              >구매 시 <b>${point}</b> 적립</span
             >
           </p>
         </div>
@@ -128,6 +129,20 @@ const generateTemplate = (
   `;
 
   return target === 'cartModal' ? cartModalTemplate : headerPopupTemplate;
+};
+
+const updatePrice = (element, count) => {
+  const target = element.closest('.basket-product__wrapper');
+  const regularPrice = target.querySelector(
+    '.basket-product__price__discount'
+  ).textContent;
+  const totalPrice = target.querySelector('.basket-product__total__price');
+  const totalPoint = target.querySelector(
+    '.basket-product__grade__description b'
+  );
+  const price = getPriceNumber(regularPrice) * count;
+  totalPrice.innerText = getPriceString(price);
+  totalPoint.innerText = getPriceString(price * 0.01);
 };
 
 export const closeCartModal = () => {
@@ -147,8 +162,10 @@ const handleProductCount = (countElement, target) => {
     }
 
     countElement.innerText = count;
+    updatePrice(countElement, count);
     return true;
   };
+
   return updateCount;
 };
 

--- a/src/lib/components/cartModal.js
+++ b/src/lib/components/cartModal.js
@@ -1,42 +1,58 @@
-import { getNode, insertLast } from '/src/lib';
+import pb from '/src/lib/api/pocketbase';
+import {
+  getNode,
+  insertLast,
+  handleProduct,
+  updateRecentlyViewedProducts,
+  getStorage,
+} from '/src/lib';
 
 const body = getNode('body');
 const findDataObj = {
   thumbnail: {
     dom: '.product__images__thumbnail',
-    findTarget: 'src',
+    find: 'src',
     result: '',
   },
   description: {
     dom: '.product__images__thumbnail',
-    findTarget: 'alt',
+    find: 'alt',
     result: '',
   },
   title: {
     dom: '.product__title',
-    findTarget: 'textContent',
+    find: 'textContent',
     result: '',
   },
   price: {
     dom: '.product__price',
-    findTarget: 'textContent',
+    find: 'textContent',
+    result: '',
+  },
+  id: {
+    dom: '.product',
+    find: 'href',
     result: '',
   },
 };
-
 const getPriceNumber = (string) => Number(string.replace(/[원,]/g, ''));
 const getPriceString = (number) => `${number.toLocaleString()}원`;
-const switchPrice = (string) => getPriceString(getPriceNumber(string));
+const switchPrice = (string, point) => {
+  if (!point) return getPriceString(getPriceNumber(string));
+  else {
+    const addCount = Math.round(getPriceNumber(string) * point);
+    return getPriceString(addCount);
+  }
+};
 
 const fillDataObj = (target) => {
   for (const key in findDataObj) {
-    const domElement = target.querySelector(findDataObj[key].dom);
-    if (domElement) {
-      const findTargetElement = domElement[findDataObj[key].findTarget];
-      findDataObj[key].result =
-        findTargetElement !== null ? findTargetElement.trim() : '';
-    } else {
-      findDataObj[key].result = '';
+    const domTarget = target.querySelector(findDataObj[key].dom);
+    const findTarget = domTarget ? domTarget[findDataObj[key].find] : null;
+    findDataObj[key].result = findTarget !== null ? findTarget.trim() : '';
+    if (key === 'id') {
+      console.log('key.id', key.id);
+      findDataObj.id.result = target.href.split('#')[1] || '';
     }
   }
   return { findDataObj };
@@ -46,19 +62,19 @@ const extractCartData = (product) => {
   fillDataObj(product);
 
   return {
+    id: findDataObj.id.result,
     title: findDataObj.title.result,
     price: switchPrice(findDataObj.price.result),
     thumbnail: findDataObj.thumbnail.result,
     description: findDataObj.description.result,
     count: 1,
     sum: switchPrice(findDataObj.price.result),
-    point: Math.round(getPriceNumber(findDataObj.price.result) * 0.01),
+    point: switchPrice(findDataObj.price.result, 0.01),
   };
 };
-
 const generateTemplate = (
   target,
-  { title, price, thumbnail, description, count, sum, point }
+  { id, title, price, thumbnail, description, count, sum, point }
 ) => {
   const headerPopupTemplate = /* HTML */ `
     <div class="cart-popup is--active">
@@ -80,32 +96,32 @@ const generateTemplate = (
   `;
 
   const cartModalTemplate = /* HTML */ `
-    <div class="cart-product">
-      <div class="cart-product__wrapper">
-        <span class="cart-product__title">${title}</span>
-        <div class="cart-product__price">
-          <span class="cart-product__price__discount">${price}</span>
-          <div class="cart-product__count">
-            <button class="cart-product__count__change minus">-</button>
-            <span class="cart-product__count__result">${count}</span>
-            <button class="cart-product__count__change plus is--active">
+    <div class="basket-product">
+      <div class="basket-product__wrapper">
+        <span class="basket-product__title">${title}</span>
+        <div class="basket-product__price">
+          <span class="basket-product__price__discount">${price}</span>
+          <div class="basket-product__count">
+            <button class="basket-product__count__change minus">-</button>
+            <span class="basket-product__count__result">${count}</span>
+            <button class="basket-product__count__change plus is--active">
               +
             </button>
           </div>
         </div>
-        <div class="cart-product__total">
-          <span class="cart-product__total__description">합계</span>
-          <span class="cart-product__total__price">${sum}</span>
-          <p class="cart-product__grade">
-            <span class="cart-product__grade__type">적립</span>
-            <span class="cart-product__grade__description"
-              >구매 시 ${point}원 적립</span
+        <div class="basket-product__total">
+          <span class="basket-product__total__description">합계</span>
+          <span class="basket-product__total__price">${sum}</span>
+          <p class="basket-product__grade">
+            <span class="basket-product__grade__type">적립</span>
+            <span class="basket-product__grade__description"
+              >구매 시 ${point} 적립</span
             >
           </p>
         </div>
-        <div class="cart-product__button__wrapper">
-          <button class="cart-product__button close">취소</button>
-          <button class="cart-product__button add">장바구니 담기</button>
+        <div class="basket-product__button__wrapper">
+          <button class="basket-product__button close">취소</button>
+          <button class="basket-product__button add">장바구니 담기</button>
         </div>
       </div>
     </div>
@@ -115,17 +131,15 @@ const generateTemplate = (
 };
 
 export const closeCartModal = () => {
-  const cartProduct = getNode('.cart-product');
+  const cartProduct = getNode('.basket-product');
   body.style.overflow = 'auto';
   body.removeChild(cartProduct);
 };
-
 const handleProductCount = (countElement, target) => {
   let count = parseInt(countElement.innerText);
-
   const updateCount = (operation) => {
     if (operation === 'increment') count += 1;
-    else if (operation === 'decrement') count -= 1;
+    else count -= 1;
 
     if (count <= 0) {
       alert('물건은 1개 이상 담아주세요.');
@@ -135,50 +149,51 @@ const handleProductCount = (countElement, target) => {
     countElement.innerText = count;
     return true;
   };
-
   return updateCount;
 };
 
-export const openCartModal = (e) => {
-  const currentTarget = e ? e.target.closest('.cart') : null;
-  if (currentTarget) e.preventDefault();
-  else {
-    handleProduct(e);
-    return;
-  }
-
+export const openCartModal = async (e) => {
+  e.preventDefault();
+  const cartIcon = e.target.closest('.cart');
   const product = e.target.closest('.product');
   const cartData = extractCartData(product);
   const template = generateTemplate('cartModal', cartData);
-  insertLast('body', template);
+  if (cartIcon) insertLast('body', template);
+  else if (product) {
+    handleProduct(product);
+    updateRecentlyViewedProducts();
+    return;
+  } else return;
 
-  const countElement = getNode('.cart-product__count__result');
+  const countElement = getNode('.basket-product__count__result');
   const updateCount = handleProductCount(countElement, product);
 
+  console.log('product', product);
   body.style.overflow = 'hidden';
-  getNode('.cart-product__count__change.minus').addEventListener('click', () =>
-    updateCount('decrement')
+
+  getNode('.basket-product__count__change.minus').addEventListener(
+    'click',
+    () => updateCount('decrement')
   );
-  getNode('.cart-product__count__change.plus').addEventListener('click', () =>
+  getNode('.basket-product__count__change.plus').addEventListener('click', () =>
     updateCount('increment')
   );
 
-  getNode('.cart-product .close').addEventListener('click', closeCartModal);
-  getNode('.cart-product .add').addEventListener('click', () =>
+  getNode('.basket-product .close').addEventListener('click', closeCartModal);
+  getNode('.basket-product .add').addEventListener('click', () =>
     handleAddCart(e, product, countElement)
   );
 };
 
 export const handleAddCart = (e, target, countElement) => {
   const menuLink = getNode('.menu_link');
-  console.log('click');
-  closeCartModal();
   const cartData = extractCartData(target);
   cartData.count = parseInt(countElement.innerText);
+  // setProductCount();
 
+  closeCartModal();
   const template = generateTemplate('cartPopup', cartData);
   insertLast(menuLink, template);
-
   setTimeout(() => {
     const cartPopup = getNode('.cart-popup');
     if (cartPopup) cartPopup.remove();

--- a/src/lib/components/recentBar.js
+++ b/src/lib/components/recentBar.js
@@ -40,7 +40,6 @@ const createProductTemplate = (url, thumbnailSrc, thumbnailAlt) => {
   `;
 };
 
-// TODO: imgSrc -> productId & href +productId
 const renderProduct = (target, product) => {
   const existingProduct = target.querySelector(
     `.recently__product__image[src="${product.thumbnailSrc}"]`
@@ -66,15 +65,12 @@ export const updateRecentlyViewedProducts = () => {
   });
 };
 
-export const handleProduct = (e) => {
-  e.preventDefault();
-
-  const current = e.target.closest('.product');
+export const handleProduct = (product, address) => {
+  const current = product;
   if (!current) return;
 
   const [url, thumbnail] = [current.href, current.querySelector('img')];
   if (!url) return;
-
   const existImage = document.querySelectorAll('.recently__product img');
   const existIndex = Array.from(existImage).findIndex(
     (isExist) => isExist.src === thumbnail.src
@@ -101,5 +97,5 @@ export const handleProduct = (e) => {
     thumbnailAlt: thumbnail.alt,
   });
   saveProductList('recentlyViewedProducts', storedData);
-  window.location.href = `/src/pages/detail/index.html`;
+  window.location.href = url;
 };

--- a/src/styles/components/_cartModal.scss
+++ b/src/styles/components/_cartModal.scss
@@ -38,17 +38,20 @@
     padding: 8px 0;
   }
   &__name {
+    @include size(144px);
     @include font(size $labelSmall weight 600);
     color: $gray300;
     padding-bottom: 8px;
+    overflow: hidden;
     white-space: nowrap;
+    text-overflow: ellipsis;
   }
   &__add-cart {
     @include font(size $labelSmall weight 400);
     color: $content;
   }
 }
-// shopping basket
+
 .basket-product {
   @include size(100vw, 100vh);
   @include absolute();


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| --------------- |
|       ![화면 기록 2024-01-12 오후 4 06 58](https://github.com/FRONTENDSCHOOL8/super-market/assets/91606951/69955ccd-88cd-4fdd-bdc3-014c1fd25873)       |

### 📝 Details
- 메인페이지 html 상품 템플릿 제거
- 장바구니 모달과 팝업 관련 리팩토링
- 장바구니 모달에서 상품 수 변경 시 총합과 포인트에 반영
- 장바구니에 상품이 담겼을 경우 상단 팝업의 상품 이름이 같다면 영역에 맞게 자른 후 '...' 붙도록 수정
- 데이터베이스 사용해서 상품 카드는 최대 16개씩 상단, 하단에 가져오기
- 데이터베이스 연결 후 장바구니 아이콘 클릭시 장바구니 담기 모달 연결 '장바구니 담기' 클릭 시 팝업
