### PR TITLE
feat(feat/kim/#109): 회원가입 페이지 아이디, 이메일 중복 확인 체크 기능 추가

### DIFF
--- a/src/pages/login/index.js
+++ b/src/pages/login/index.js
@@ -28,7 +28,6 @@ const userPw = getNode('#loginUserPw');
 const userData = await pb.collection('users').getList(1, 1, {
   filter: 'username = "dhtldka"',
 });
-console.log(userData);
 
 // 로그인 기능
 

--- a/src/pages/login/index.js
+++ b/src/pages/login/index.js
@@ -25,6 +25,11 @@ const userInputs = getNodes('.login-input-group');
 const userId = getNode('#loginUserId');
 const userPw = getNode('#loginUserPw');
 
+const userData = await pb.collection('users').getList(1, 1, {
+  filter: 'username = "dhtldka"',
+});
+console.log(userData);
+
 // 로그인 기능
 
 const handleLogin = async (e) => {

--- a/src/pages/register/index.html
+++ b/src/pages/register/index.html
@@ -192,7 +192,11 @@
                   minlength="6"
                   required
                 />
-                <button class="register-input-button" id="id-verify-button">
+                <button
+                  type="button"
+                  class="register-input-button"
+                  id="id-verify-button"
+                >
                   중복확인
                 </button>
                 <span class="register-error-message" id="useridError"
@@ -276,7 +280,13 @@
                   class="register-input-group"
                   required
                 />
-                <button class="register-input-button">중복확인</button>
+                <button
+                  type="button"
+                  class="register-input-button"
+                  id="email-verify-button"
+                >
+                  중복확인
+                </button>
                 <span class="register-error-message" id="userEmailError"
                   >이메일 형식으로 입력해주세요.</span
                 >
@@ -300,7 +310,7 @@
                   인증번호 받기
                 </button>
                 <span class="register-error-message" id="userTelError"
-                  >휴대폰 번호를 입력해 주세요.</span
+                  >휴대폰 번호를 올바르게 입력해 주세요.</span
                 >
               </div>
 
@@ -568,7 +578,9 @@
 
             <!-- 가입하기 버튼 영역 -->
             <section class="request-register">
-              <button disabled="false" class="register-button">가입하기</button>
+              <button type="button" disabled="false" class="register-button">
+                가입하기
+              </button>
             </section>
           </form>
         </div>

--- a/src/pages/register/index.js
+++ b/src/pages/register/index.js
@@ -5,16 +5,16 @@ import {
   sliceNumberMaxLength,
   validationInput,
 } from '/src/lib';
-import pb from '/src/lib/api/pocketbase';
+import pb from '/src/lib/api/pocketbase.js';
 import '/src/styles/style.scss';
 
-initHeader();
-
 const userIdInput = getNode('#userId');
+const idVerifyBtn = getNode('#id-verify-button');
 const userPwInput = getNode('#userPw');
 const userPwConfirmInput = getNode('#userPwConfirm');
 const userNameInput = getNode('#userName');
 const userEmailInput = getNode('#userEmail');
+const emailVerifyBtn = getNode('#email-verify-button');
 const userTelInput = getNode('#userTel');
 const userBirthYear = getNode('#birthYear');
 const userBirthMonth = getNode('#birthMonth');
@@ -24,51 +24,61 @@ const registerBtn = getNode('.register-button');
 const requiredInputs = getNodes('.register-input-group[required]');
 const requiredCheckboxes = getNodes('.agree-state-checkbox[required]');
 
+initHeader();
+
 // 회원가입 기능
 
-const sendRegisterUserData = async (e) => {
-  e.preventDefault();
+const sendRegisterUserData = async () => {
+  if (!checkIdDuplication) {
+    alert('아이디 중복 확인을 진행해 주세요.');
+    return;
+  }
+  if (!checkEmailDuplication) {
+    alert('이메일 중복 확인을 진행해 주세요.');
+    return;
+  }
+  if (checkIdDuplication && checkEmailDuplication) {
+    const userGender = getNode('.register-gender-group:checked');
+    const userTerms = getNode('#agree-benefit');
 
-  const userGender = getNode('.register-gender-group:checked');
-  const userTerms = getNode('#agree-benefit');
+    const userData = {
+      username: userIdInput.value,
+      password: userPwInput.value,
+      passwordConfirm: userPwConfirmInput.value,
+      email: userEmailInput.value,
+      emailVisibility: true,
+      name: userNameInput.value,
+      phone_number: userTelInput.value,
+      gender: userGender.value,
+      birthday: `${userBirthYear.value}-${userBirthMonth.value}-${userBirthDay.value} 00:00:00.123Z`,
+      terms: userTerms.checked,
+    };
 
-  const userData = {
-    username: userIdInput.value,
-    password: userPwInput.value,
-    passwordConfirm: userPwConfirmInput.value,
-    email: userEmailInput.value,
-    name: userNameInput.value,
-    phone_number: userTelInput.value,
-    gender: userGender.value,
-    birthday: `${userBirthYear.value}-${userBirthMonth.value}-${userBirthDay.value} 00:00:00.123Z`,
-    terms: userTerms.checked,
-  };
-
-  const cartData = {
-    product: '{}',
-  };
-  let cart;
-  pb.collection('cart')
-    .create(cartData)
-    .then(async () => {
-      cart = await pb.collection('cart').getList(1, 1, {
-        sort: '-created',
+    const cartData = {
+      product: '{}',
+    };
+    let cart;
+    pb.collection('cart')
+      .create(cartData)
+      .then(async () => {
+        cart = await pb.collection('cart').getList(1, 1, {
+          sort: '-created',
+        });
+      })
+      .then(() => {
+        userData['cart_id'] = cart.items[0].id;
+      })
+      .then(() => {
+        pb.collection('users').create(userData);
+      })
+      .then(() => {
+        alert('회원가입을 축하드립니다. 로그인 페이지로 이동합니다.');
+        location.href = '/src/pages/login/';
+      })
+      .catch(() => {
+        alert('아이디 또는 이메일이 중복됩니다.');
       });
-      console.log(cart);
-    })
-    .then(() => {
-      userData['cart_id'] = cart.items[0].id;
-    })
-    .then(() => {
-      pb.collection('users').create(userData);
-    })
-    .then(() => {
-      alert('회원가입을 축하드립니다. 로그인 페이지로 이동합니다.');
-      location.href = '/src/pages/login/';
-    })
-    .catch(() => {
-      alert('아이디 또는 이메일이 중복됩니다.');
-    });
+  }
 };
 
 registerBtn.addEventListener('click', sendRegisterUserData);
@@ -114,6 +124,56 @@ sliceNumberMaxLength(userBirthDay);
 validationInput('#birthYear', /^19\d{2}$|^20\d{2}$|^2100$/);
 validationInput('#birthMonth', /^(0[1-9]|1[0-2])$/);
 validationInput('#birthDay', /^(0[1-9]|[1-2]\d|3[0-1])$/);
+
+// 아이디 중복 확인
+
+let checkIdDuplication;
+
+const handleCheckIdDuplication = async () => {
+  const userData = await pb.collection('users').getList(1, 1, {
+    filter: `username = "${userIdInput.value}"`,
+  });
+  if (userData.totalItems) {
+    alert('이미 사용 중인 아이디입니다. 다른 아이디를 입력해주세요.');
+    checkIdDuplication = false;
+  } else {
+    alert('사용 가능한 아이디입니다.');
+    checkIdDuplication = true;
+  }
+};
+
+idVerifyBtn.addEventListener('click', handleCheckIdDuplication);
+
+const handleCheckDuplicationIdInput = () => {
+  checkIdDuplication = false;
+};
+
+userIdInput.addEventListener('input', handleCheckDuplicationIdInput);
+
+// 이메일 중복 확인
+
+let checkEmailDuplication;
+
+const handleCheckEmailDuplication = async () => {
+  const userData = await pb.collection('users').getList(1, 1, {
+    filter: `email = "${userEmailInput.value}"`,
+  });
+  if (userData.totalItems) {
+    alert('이미 사용 중인 이메일입니다. 다른 아이디를 입력해주세요.');
+    checkEmailDuplication = false;
+  } else {
+    alert('사용 가능한 이메일입니다.');
+    checkEmailDuplication = true;
+  }
+};
+
+emailVerifyBtn.addEventListener('click', handleCheckEmailDuplication);
+
+const handleCheckDuplicationEmailInput = () => {
+  checkEmailDuplication = false;
+};
+
+userEmailInput.addEventListener('input', handleCheckDuplicationEmailInput);
 
 // 가입하기 버튼 활성화
 


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| --------------- |
|**아이디 중복확인 기능**|
|![아이디 중복확인](https://github.com/FRONTENDSCHOOL8/super-market/assets/145115283/341a2fc3-462b-4fa9-87a2-574839813049)|
|**이메일 중복확인 기능**|
|![이메일 중복확인](https://github.com/FRONTENDSCHOOL8/super-market/assets/145115283/98add95b-f939-4f73-b87d-6001b41778bb)|
|**아이디, 이메일 중복 확인 진행 및 통과 시에만 가입 가능 기능**|
|![회원가입](https://github.com/FRONTENDSCHOOL8/super-market/assets/145115283/ddb88670-834c-460a-8f2a-3bb0c4a349fe)|

### 📝 Details

- 데이터 통신을 통한 아이디 및 이메일 중복 확인 기능
    - 포켓베이스 상 Email Public 옵션 off인 경우 중복확인 불가로 인하여 가입 시 emailVisibility: true 값 추가 전달
- 아이디 및 이메일 중복확인 모두 통과할 경우에만 가입 가능
    - 안 되어있는 항목은 얼럿창에 별도로 명시적으로 알려줌
