### PR TITLE
modify(feat/kim/#141): 회원가입 페이지 중복확인, 추천인 아이디 확인 기능 보완

### DIFF
--- a/src/pages/register/index.js
+++ b/src/pages/register/index.js
@@ -141,6 +141,7 @@ const handleCheckIdDuplication = async () => {
     } else {
       alert('사용 가능한 아이디입니다.');
       checkIdDuplication = true;
+      idVerifyBtn.disabled = true;
     }
   }
 };
@@ -149,6 +150,7 @@ idVerifyBtn.addEventListener('click', handleCheckIdDuplication);
 
 const handleCheckDuplicationIdInput = () => {
   checkIdDuplication = false;
+  idVerifyBtn.disabled = false;
 };
 
 userIdInput.addEventListener('input', handleCheckDuplicationIdInput);
@@ -171,6 +173,7 @@ const handleCheckEmailDuplication = async () => {
     } else {
       alert('사용 가능한 이메일입니다.');
       checkEmailDuplication = true;
+      emailVerifyBtn.disabled = true;
     }
   }
 };
@@ -179,6 +182,7 @@ emailVerifyBtn.addEventListener('click', handleCheckEmailDuplication);
 
 const handleCheckDuplicationEmailInput = () => {
   checkEmailDuplication = false;
+  emailVerifyBtn.disabled = false;
 };
 
 userEmailInput.addEventListener('input', handleCheckDuplicationEmailInput);
@@ -289,6 +293,7 @@ const handleCheckRecommenderIdDuplication = async () => {
     if (userData.totalItems) {
       alert('추천인 아이디가 확인되었습니다.');
       checkRecommenderIdDuplication = true;
+      recommenderIdVerifyBtn.disabled = true;
     } else {
       alert('입력하신 추천인 아이디가 존재하지 않습니다.');
       checkRecommenderIdDuplication = false;
@@ -299,4 +304,13 @@ const handleCheckRecommenderIdDuplication = async () => {
 recommenderIdVerifyBtn.addEventListener(
   'click',
   handleCheckRecommenderIdDuplication
+);
+
+const handlehandleCheckRecommenderIdInput = () => {
+  recommenderIdVerifyBtn.disabled = false;
+};
+
+recommenderIdInput.addEventListener(
+  'input',
+  handlehandleCheckRecommenderIdInput
 );

--- a/src/styles/pages/_register.scss
+++ b/src/styles/pages/_register.scss
@@ -84,6 +84,11 @@
   border: 1px solid $primary;
   background-color: $white;
   color: $primary;
+  &:disabled {
+    color: $white;
+    background: $gray200;
+    border: 1px solid $gray300;
+  }
 }
 
 #userTel,


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| --------------- |
|아이디 중복 확인|
|![아이디 중복확인](https://github.com/FRONTENDSCHOOL8/super-market/assets/145115283/03fa93c3-fea2-492e-bd33-3f2f120a3220)|
|이메일 중복 확인|
|![이메일 중복확인](https://github.com/FRONTENDSCHOOL8/super-market/assets/145115283/159afc6e-6149-4f0f-8417-bc2a299f313b)|
|추천인 아이디 확인|
|![추천인 아이디 확인](https://github.com/FRONTENDSCHOOL8/super-market/assets/145115283/5a8dab5c-7a45-4825-b57c-8f9c9b33ec2c)|

### 📝 Details

- 아이디 중복확인 진행 시 중복확인 버튼 음영처리
- 이메일 중복확인 진행 시 중복확인 버튼 음영처리
- 추천인 아이디 확인 진행 시 아이디 확인 버튼 음영처리
